### PR TITLE
Upgrade to IntelliJ 2020.3

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -15,6 +15,6 @@ jobs:
       - name: "Build, Tag, and Push Docker Image"
         run: |
           echo "${{secrets.DOCKER_HUB_TOKEN}}" | docker login -u gopalkrishnaps --password-stdin
-          docker build -t gopalkrishnaps/intellij:2020.2.3 -t gopalkrishnaps/intellij:latest .
+          docker build -t gopalkrishnaps/intellij:2020.3 -t gopalkrishnaps/intellij:latest .
           docker push gopalkrishnaps/intellij:latest
-          docker push gopalkrishnaps/intellij:2020.2.3
+          docker push gopalkrishnaps/intellij:2020.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openkbs/ubuntu-bionic-jdk-mvn-py3
 
-ARG INTELLIJ_VERSION="ideaIC-2020.2.3"
+ARG INTELLIJ_VERSION="ideaIC-2020.3"
 
 ARG INTELLIJ_IDE_TAR=${INTELLIJ_VERSION}.tar.gz
 
@@ -13,10 +13,4 @@ RUN wget -nv https://download-cf.jetbrains.com/idea/${INTELLIJ_IDE_TAR} && \
     tar tzf ${INTELLIJ_IDE_TAR} | head -1 | sed -e 's/\/.*//' | xargs -I{} ln -s {} idea && \
     rm ${INTELLIJ_IDE_TAR} && \
     echo idea.config.path=/etc/idea/config >> idea/bin/idea.properties && \
-    chmod -R 777 /etc/idea && \
-    wget https://plugins.jetbrains.com/files/6954/94741/kotlin-plugin-1.4.0-release-IJ2020.2-1.zip && \
-    unzip kotlin-plugin-1.4.0-release-IJ2020.2-1.zip && \
-    rm -rf /opt/idea/plugins/Kotlin && \
-    mv Kotlin /opt/idea/plugins/ && \
-    rm kotlin-plugin-1.4.0-release-IJ2020.2-1.zip
-    
+    chmod -R 777 /etc/idea


### PR DESCRIPTION
Removed manual addition of kotlin as the new version of IntelliJ is shipped with kotlin version 1.4.10